### PR TITLE
Integrates Multi chain config to prover

### DIFF
--- a/contract-tools/xchain/xchain.go
+++ b/contract-tools/xchain/xchain.go
@@ -686,7 +686,7 @@ func (a *aggregator) sendDeal(ctx context.Context, aggCommp cid.Cid, transferID 
 			EndEpoch:             dealEnd,
 			StoragePricePerEpoch: fbig.NewInt(0),
 			ProviderCollateral:   providerCollateral,
-			Label:                dealLabel, // TOOD we might need to set this, we'll see
+			Label:                dealLabel,
 		},
 		// Signature is unchecked since client is smart contract
 		ClientSignature: crypto.Signature{
@@ -993,11 +993,11 @@ func loadPrivateKey(cfg *Config) (*bind.TransactOpts, error) {
 
 	// Import existing key
 	a, err := ks.Import(keyJSON, os.Getenv("XCHAIN_PASSPHRASE"), os.Getenv("XCHAIN_PASSPHRASE"))
-	if err := ks.Unlock(a, os.Getenv("XCHAIN_PASSPHRASE")); err != nil {
-		return nil, fmt.Errorf("failed to unlock keystore: %w", err)
-	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to import key %s: %w", cfg.ClientAddr, err)
+	}
+	if err := ks.Unlock(a, os.Getenv("XCHAIN_PASSPHRASE")); err != nil {
+		return nil, fmt.Errorf("failed to unlock keystore: %w", err)
 	}
 
 	return bind.NewKeyStoreTransactorWithChainID(ks, a, big.NewInt(int64(cfg.ChainID)))

--- a/contract-tools/xchain/xchain_test.go
+++ b/contract-tools/xchain/xchain_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test function to test chainID encoding
+func TestChainIdEncoding(t *testing.T) {
+	configPath := "~/.xchain/config.json" // Replace with the actual path to your config file
+
+	config, err := LoadConfig(configPath); 
+	if err != nil {
+		t.Fatalf("failed to unmarshal config: %v", err)
+	}
+
+	// Connect to the Ethereum client
+	client, err := ethclient.Dial(config.Api)
+	if err != nil {
+		t.Fatalf("failed to connect to the Ethereum client: %v", err)
+	}
+
+	// Query the chain ID
+	chainID, err := client.ChainID(context.Background())
+	if err != nil {
+		t.Fatalf("failed to get chain ID: %v", err)
+	}
+
+	// Encode the chainID
+	encodedChainID, err := encodeChainID(chainID)
+	if err != nil {
+		t.Fatalf("failed to encode chainID: %v", err)
+	}
+
+	fmt.Println("Encoded chainID: ", encodedChainID)
+	fmt.Println("chainID: ", chainID)
+	hexEncodedChainID := hex.EncodeToString(encodedChainID)
+    fmt.Printf("Encoded ChainID in Hex: %s\n", hexEncodedChainID)
+	decodedChainID, err := decodeChainID(encodedChainID)
+	if err != nil {
+		t.Fatalf("failed to decode chainID: %v", err)
+	}
+	fmt.Println("Decoded chainID: ", decodedChainID)
+	assert.Equal(t, decodedChainID, chainID, "Encoded chainID does not match expected value")
+}
+
+func decodeChainID(data []byte) (*big.Int, error) {
+    // Define the ABI arguments
+    uint256Type, err := abi.NewType("uint256", "", nil)
+    if err != nil {
+        return nil, fmt.Errorf("failed to create uint256 type: %w", err)
+    }
+
+    arguments := abi.Arguments{
+        {Type: uint256Type}, // chainID is a uint256 in Solidity
+    }
+
+    // Unpack the byte array into a slice of interface{}
+    unpacked, err := arguments.Unpack(data)
+    if err != nil {
+        return nil, fmt.Errorf("failed to decode chainID: %w", err)
+    }
+
+    // Extract the chainID from the unpacked slice
+    if len(unpacked) == 0 {
+        return nil, fmt.Errorf("no data unpacked")
+    }
+
+    chainID, ok := unpacked[0].(*big.Int)
+    if !ok {
+        return nil, fmt.Errorf("failed to assert type to *big.Int")
+    }
+
+    return chainID, nil
+}

--- a/src/Cid.sol
+++ b/src/Cid.sol
@@ -8,25 +8,40 @@ import "./Const.sol";
 
 library Cid {
     // cidToPieceCommitment converts a CID to a piece commitment.
-    function cidToPieceCommitment(bytes memory _cb) internal pure returns (bytes32) {
+    function cidToPieceCommitment(
+        bytes memory _cb
+    ) internal pure returns (bytes32) {
         require(
             _cb.length == CID_COMMP_HEADER_LENGTH + MERKLE_TREE_NODE_SIZE,
             "wrong length of CID"
         );
         require(
-            keccak256(abi.encodePacked(_cb[0], _cb[1], _cb[2], _cb[3], _cb[4], _cb[5], _cb[6])) ==
-                keccak256(abi.encodePacked(CID_COMMP_HEADER)),
+            keccak256(
+                abi.encodePacked(
+                    _cb[0],
+                    _cb[1],
+                    _cb[2],
+                    _cb[3],
+                    _cb[4],
+                    _cb[5],
+                    _cb[6]
+                )
+            ) == keccak256(abi.encodePacked(CID_COMMP_HEADER)),
             "wrong content of CID header"
         );
         bytes32 res;
         assembly {
-            res := mload(add(add(_cb, CID_COMMP_HEADER_LENGTH), MERKLE_TREE_NODE_SIZE))
+            res := mload(
+                add(add(_cb, CID_COMMP_HEADER_LENGTH), MERKLE_TREE_NODE_SIZE)
+            )
         }
         return res;
     }
 
     // pieceCommitmentToCid converts a piece commitment to a CID.
-    function pieceCommitmentToCid(bytes32 _commp) internal pure returns (bytes memory) {
+    function pieceCommitmentToCid(
+        bytes32 _commp
+    ) internal pure returns (bytes memory) {
         bytes memory cb = abi.encodePacked(CID_COMMP_HEADER, _commp);
         return cb;
     }

--- a/src/Const.sol
+++ b/src/Const.sol
@@ -14,5 +14,8 @@ uint8 constant MERKLE_TREE_NODE_SIZE = 32;
 bytes32 constant TRUNCATOR = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3f;
 uint64 constant BYTES_IN_INT = 8;
 uint64 constant CHECKSUM_SIZE = 16;
-uint64 constant ENTRY_SIZE = uint64(MERKLE_TREE_NODE_SIZE) + 2 * BYTES_IN_INT + CHECKSUM_SIZE;
+uint64 constant ENTRY_SIZE = uint64(MERKLE_TREE_NODE_SIZE) +
+    2 *
+    BYTES_IN_INT +
+    CHECKSUM_SIZE;
 uint64 constant BYTES_IN_DATA_SEGMENT_ENTRY = 2 * MERKLE_TREE_NODE_SIZE;

--- a/src/Oracles.sol
+++ b/src/Oracles.sol
@@ -34,10 +34,20 @@ contract ForwardingProofMockBridge is IBridgeContract {
     }
 
     function _execute(string calldata _sourceChain_, string calldata sourceAddress_, bytes calldata payload_) external override {
-       require(StringsEqual(_sourceChain_, "FIL"), "Only FIL proofs supported");   
+       require(StringsEqual(_sourceChain_, "filecoin-2") && block.chainid == 314159, "Only FIL proofs supported");   
        require(StringsEqual(senderHex, sourceAddress_), "Only sender can execute");
        DataAttestation memory attestation = abi.decode(payload_, (DataAttestation));
        IReceiveAttestation(receiver).proveDataStored(attestation);
+    }
+}
+
+contract DebugMockBridge is IBridgeContract {
+    event ReceivedAttestation(bytes commP, string sourceAddress);
+
+    function _execute(string calldata _sourceChain_, string calldata sourceAddress_, bytes calldata payload_) external override {
+       require(StringsEqual(_sourceChain_, "filecoin-2") && block.chainid == 314159, "Only FIL proofs supported");   
+        DataAttestation memory attestation = abi.decode(payload_, (DataAttestation));
+        emit ReceivedAttestation(attestation.commP, sourceAddress_);
     }
 }
 

--- a/src/Oracles.sol
+++ b/src/Oracles.sol
@@ -2,10 +2,14 @@
 pragma solidity ^0.8.17;
 
 import {AxelarExecutable} from "lib/axelar-gmp-sdk-solidity/contracts/executable/AxelarExecutable.sol";
-import { StringToAddress } from 'lib/axelar-gmp-sdk-solidity/contracts/libs/AddressString.sol';
+import {StringToAddress} from "lib/axelar-gmp-sdk-solidity/contracts/libs/AddressString.sol";
 
 interface IBridgeContract {
-    function _execute(string calldata sourceChain_, string calldata sourceAddress_, bytes calldata payload_) external;
+    function _execute(
+        string calldata sourceChain_,
+        string calldata sourceAddress_,
+        bytes calldata payload_
+    ) external;
 }
 
 struct DataAttestation {
@@ -20,33 +24,60 @@ interface IReceiveAttestation {
 }
 
 // This contract forwards between contracts on the same chain
-// Useful for integration tests of flows involving bridges 
-// It expects a DealAttestation struct as payload from 
+// Useful for integration tests of flows involving bridges
+// It expects a DealAttestation struct as payload from
 // an address with string encoding == senderHex and forwards to
 // an L2 on ramp contract at receiver address
 contract ForwardingProofMockBridge is IBridgeContract {
     address public receiver;
     string public senderHex;
 
-    function setSenderReceiver(string calldata senderHex_, address receiver_) external {
+    function setSenderReceiver(
+        string calldata senderHex_,
+        address receiver_
+    ) external {
         receiver = receiver_;
         senderHex = senderHex_;
     }
 
-    function _execute(string calldata _sourceChain_, string calldata sourceAddress_, bytes calldata payload_) external override {
-       require(StringsEqual(_sourceChain_, "filecoin-2"), "Only FIL proofs supported");   
-       require(StringsEqual(senderHex, sourceAddress_), "Only sender can execute");
-       DataAttestation memory attestation = abi.decode(payload_, (DataAttestation));
-       IReceiveAttestation(receiver).proveDataStored(attestation);
+    function _execute(
+        string calldata _sourceChain_,
+        string calldata sourceAddress_,
+        bytes calldata payload_
+    ) external override {
+        require(
+            StringsEqual(_sourceChain_, "filecoin-2"),
+            "Only FIL proofs supported"
+        );
+        require(
+            StringsEqual(senderHex, sourceAddress_),
+            "Only sender can execute"
+        );
+        DataAttestation memory attestation = abi.decode(
+            payload_,
+            (DataAttestation)
+        );
+        IReceiveAttestation(receiver).proveDataStored(attestation);
     }
 }
 
 contract DebugMockBridge is IBridgeContract {
     event ReceivedAttestation(bytes commP, string sourceAddress);
 
-    function _execute(string calldata _sourceChain_, string calldata sourceAddress_, bytes calldata payload_) external override {
-       require(StringsEqual(_sourceChain_, "filecoin-2") && block.chainid == 314159, "Only FIL proofs supported");   
-        DataAttestation memory attestation = abi.decode(payload_, (DataAttestation));
+    function _execute(
+        string calldata _sourceChain_,
+        string calldata sourceAddress_,
+        bytes calldata payload_
+    ) external override {
+        require(
+            StringsEqual(_sourceChain_, "filecoin-2") &&
+                block.chainid == 314159,
+            "Only FIL proofs supported"
+        );
+        DataAttestation memory attestation = abi.decode(
+            payload_,
+            (DataAttestation)
+        );
         emit ReceivedAttestation(attestation.commP, sourceAddress_);
     }
 }
@@ -54,10 +85,17 @@ contract DebugMockBridge is IBridgeContract {
 contract AxelarBridgeDebug is AxelarExecutable {
     event ReceivedAttestation(bytes commP, string sourceAddress);
 
-    constructor(address _gateway) AxelarExecutable(_gateway){}
+    constructor(address _gateway) AxelarExecutable(_gateway) {}
 
-    function _execute(string calldata, string calldata sourceAddress_, bytes calldata payload_) internal override {
-        DataAttestation memory attestation = abi.decode(payload_, (DataAttestation));
+    function _execute(
+        string calldata,
+        string calldata sourceAddress_,
+        bytes calldata payload_
+    ) internal override {
+        DataAttestation memory attestation = abi.decode(
+            payload_,
+            (DataAttestation)
+        );
         emit ReceivedAttestation(attestation.commP, sourceAddress_);
     }
 }
@@ -65,30 +103,52 @@ contract AxelarBridgeDebug is AxelarExecutable {
 contract AxelarBridge is AxelarExecutable {
     address public receiver;
     address public sender;
-    event ReceivedAttestation(string sourceChain, string sourceAddress, bytes commP);
+    event ReceivedAttestation(
+        string sourceChain,
+        string sourceAddress,
+        bytes commP
+    );
     using StringToAddress for string;
 
-    constructor(address _gateway) AxelarExecutable(_gateway){}
+    constructor(address _gateway) AxelarExecutable(_gateway) {}
 
     function setSenderReceiver(address sender_, address receiver_) external {
         receiver = receiver_;
         sender = sender_;
     }
 
-    function _execute(string calldata _sourceChain_, string calldata sourceAddress_, bytes calldata payload_) internal override {
-       DataAttestation memory attestation = abi.decode(payload_, (DataAttestation));
-       emit ReceivedAttestation(_sourceChain_, sourceAddress_, attestation.commP);
-       require(StringsEqual(_sourceChain_, 'filecoin-2'), 'Only filecoin supported');   
-       require(sender == sourceAddress_.toAddress(), 'Only registered sender addr can execute');
-       
-       IReceiveAttestation(receiver).proveDataStored(attestation);
+    function _execute(
+        string calldata _sourceChain_,
+        string calldata sourceAddress_,
+        bytes calldata payload_
+    ) internal override {
+        DataAttestation memory attestation = abi.decode(
+            payload_,
+            (DataAttestation)
+        );
+        emit ReceivedAttestation(
+            _sourceChain_,
+            sourceAddress_,
+            attestation.commP
+        );
+        require(
+            StringsEqual(_sourceChain_, "filecoin-2"),
+            "Only filecoin supported"
+        );
+        require(
+            sender == sourceAddress_.toAddress(),
+            "Only registered sender addr can execute"
+        );
+
+        IReceiveAttestation(receiver).proveDataStored(attestation);
     }
 }
 
 contract DebugReceiver is IReceiveAttestation {
     event ReceivedAttestation(bytes Commp);
+
     function proveDataStored(DataAttestation calldata attestation_) external {
-        emit ReceivedAttestation(attestation_.commP);        
+        emit ReceivedAttestation(attestation_.commP);
     }
 }
 

--- a/src/Oracles.sol
+++ b/src/Oracles.sol
@@ -34,7 +34,7 @@ contract ForwardingProofMockBridge is IBridgeContract {
     }
 
     function _execute(string calldata _sourceChain_, string calldata sourceAddress_, bytes calldata payload_) external override {
-       require(StringsEqual(_sourceChain_, "filecoin-2") && block.chainid == 314159, "Only FIL proofs supported");   
+       require(StringsEqual(_sourceChain_, "filecoin-2"), "Only FIL proofs supported");   
        require(StringsEqual(senderHex, sourceAddress_), "Only sender can execute");
        DataAttestation memory attestation = abi.decode(payload_, (DataAttestation));
        IReceiveAttestation(receiver).proveDataStored(attestation);

--- a/src/Prover-Axelar.sol
+++ b/src/Prover-Axelar.sol
@@ -1,23 +1,23 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { MarketAPI } from "lib/filecoin-solidity/contracts/v0.8/MarketAPI.sol";
-import { CommonTypes } from "lib/filecoin-solidity/contracts/v0.8/types/CommonTypes.sol";
-import { MarketTypes } from "lib/filecoin-solidity/contracts/v0.8/types/MarketTypes.sol";
-import { AccountTypes } from "lib/filecoin-solidity/contracts/v0.8/types/AccountTypes.sol";
-import { CommonTypes } from "lib/filecoin-solidity/contracts/v0.8/types/CommonTypes.sol";
-import { AccountCBOR } from "lib/filecoin-solidity/contracts/v0.8/cbor/AccountCbor.sol";
-import { MarketCBOR } from "lib/filecoin-solidity/contracts/v0.8/cbor/MarketCbor.sol";
-import { BytesCBOR } from "lib/filecoin-solidity/contracts/v0.8/cbor/BytesCbor.sol";
-import { BigInts } from "lib/filecoin-solidity/contracts/v0.8/utils/BigInts.sol";
-import { CBOR } from "solidity-cborutils/contracts/CBOR.sol";
-import { Misc } from "lib/filecoin-solidity/contracts/v0.8/utils/Misc.sol";
-import { FilAddresses } from "lib/filecoin-solidity/contracts/v0.8/utils/FilAddresses.sol";
-import { DataAttestation, IBridgeContract, StringsEqual } from "./Oracles.sol";
+import {MarketAPI} from "lib/filecoin-solidity/contracts/v0.8/MarketAPI.sol";
+import {CommonTypes} from "lib/filecoin-solidity/contracts/v0.8/types/CommonTypes.sol";
+import {MarketTypes} from "lib/filecoin-solidity/contracts/v0.8/types/MarketTypes.sol";
+import {AccountTypes} from "lib/filecoin-solidity/contracts/v0.8/types/AccountTypes.sol";
+import {CommonTypes} from "lib/filecoin-solidity/contracts/v0.8/types/CommonTypes.sol";
+import {AccountCBOR} from "lib/filecoin-solidity/contracts/v0.8/cbor/AccountCbor.sol";
+import {MarketCBOR} from "lib/filecoin-solidity/contracts/v0.8/cbor/MarketCbor.sol";
+import {BytesCBOR} from "lib/filecoin-solidity/contracts/v0.8/cbor/BytesCbor.sol";
+import {BigInts} from "lib/filecoin-solidity/contracts/v0.8/utils/BigInts.sol";
+import {CBOR} from "solidity-cborutils/contracts/CBOR.sol";
+import {Misc} from "lib/filecoin-solidity/contracts/v0.8/utils/Misc.sol";
+import {FilAddresses} from "lib/filecoin-solidity/contracts/v0.8/utils/FilAddresses.sol";
+import {DataAttestation, IBridgeContract, StringsEqual} from "./Oracles.sol";
 import {Strings} from "lib/openzeppelin-contracts/contracts/utils/Strings.sol";
 import {AxelarExecutable} from "lib/axelar-gmp-sdk-solidity/contracts/executable/AxelarExecutable.sol";
-import { IAxelarGateway } from 'lib/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGateway.sol';
-import { IAxelarGasService } from 'lib/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGasService.sol';
+import {IAxelarGateway} from "lib/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGateway.sol";
+import {IAxelarGasService} from "lib/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGasService.sol";
 
 using CBOR for CBOR.CBORBuffer;
 
@@ -29,10 +29,11 @@ contract DealClient is AxelarExecutable {
     uint64 public constant AUTHENTICATE_MESSAGE_METHOD_NUM = 2643134072;
     uint64 public constant DATACAP_RECEIVER_HOOK_METHOD_NUM = 3726118371;
     uint64 public constant MARKET_NOTIFY_DEAL_METHOD_NUM = 4186741094;
-    address public constant MARKET_ACTOR_ETH_ADDRESS = address(0xff00000000000000000000000000000000000005);
-    address public constant DATACAP_ACTOR_ETH_ADDRESS = address(0xfF00000000000000000000000000000000000007);
-    uint256 public constant AXELAR_GAS_FEE = 100000000000000000; // Start with 0.1 FIL 
-
+    address public constant MARKET_ACTOR_ETH_ADDRESS =
+        address(0xff00000000000000000000000000000000000005);
+    address public constant DATACAP_ACTOR_ETH_ADDRESS =
+        address(0xfF00000000000000000000000000000000000007);
+    uint256 public constant AXELAR_GAS_FEE = 100000000000000000; // Start with 0.1 FIL
 
     struct DestinationChain {
         string chainName;
@@ -51,7 +52,10 @@ contract DealClient is AxelarExecutable {
     mapping(bytes => uint256) public providerGasFunds; // Funds set aside for calling oracle by provider
     mapping(uint256 => DestinationChain) public chainIdToDestinationChain;
 
-    constructor(address _gateway, address _gasReceiver) AxelarExecutable(_gateway) {
+    constructor(
+        address _gateway,
+        address _gasReceiver
+    ) AxelarExecutable(_gateway) {
         gasService = IAxelarGasService(_gasReceiver);
     }
 
@@ -61,16 +65,21 @@ contract DealClient is AxelarExecutable {
         address[] calldata destinationAddresses
     ) external {
         require(
-            chainIds.length == destinationChains.length && destinationChains.length == destinationAddresses.length,
+            chainIds.length == destinationChains.length &&
+                destinationChains.length == destinationAddresses.length,
             "Input arrays must have the same length"
         );
-    
+
         for (uint i = 0; i < chainIds.length; i++) {
             require(
-                chainIdToDestinationChain[chainIds[i]].destinationAddress == address(0),
+                chainIdToDestinationChain[chainIds[i]].destinationAddress ==
+                    address(0),
                 "Destination chains already configured for the chainId"
             );
-            chainIdToDestinationChain[chainIds[i]] = DestinationChain(destinationChains[i], destinationAddresses[i]);
+            chainIdToDestinationChain[chainIds[i]] = DestinationChain(
+                destinationChains[i],
+                destinationAddresses[i]
+            );
         }
     }
 
@@ -84,29 +93,56 @@ contract DealClient is AxelarExecutable {
     // and the completion of this call marks the success of PublishStorageDeals
     // @params - cbor byte array of MarketDealNotifyParams
     function dealNotify(bytes memory params) internal {
-        require(msg.sender == MARKET_ACTOR_ETH_ADDRESS, "msg.sender needs to be market actor f05");
+        require(
+            msg.sender == MARKET_ACTOR_ETH_ADDRESS,
+            "msg.sender needs to be market actor f05"
+        );
 
-        MarketTypes.MarketDealNotifyParams memory mdnp = MarketCBOR.deserializeMarketDealNotifyParams(params);
-        MarketTypes.DealProposal memory proposal = MarketCBOR.deserializeDealProposal(mdnp.dealProposal);
+        MarketTypes.MarketDealNotifyParams memory mdnp = MarketCBOR
+            .deserializeMarketDealNotifyParams(params);
+        MarketTypes.DealProposal memory proposal = MarketCBOR
+            .deserializeDealProposal(mdnp.dealProposal);
 
         pieceDeals[proposal.piece_cid.data] = mdnp.dealId;
         pieceStatus[proposal.piece_cid.data] = Status.DealPublished;
-        
-        int64 duration = CommonTypes.ChainEpoch.unwrap(proposal.end_epoch) - CommonTypes.ChainEpoch.unwrap(proposal.start_epoch);
+
+        int64 duration = CommonTypes.ChainEpoch.unwrap(proposal.end_epoch) -
+            CommonTypes.ChainEpoch.unwrap(proposal.start_epoch);
         // Expects deal label to be chainId encoded in bytes
         uint256 chainId = abi.decode(proposal.label.data, (uint256));
-        DataAttestation memory attest = DataAttestation(proposal.piece_cid.data, duration, mdnp.dealId, uint256(Status.DealPublished));
+        DataAttestation memory attest = DataAttestation(
+            proposal.piece_cid.data,
+            duration,
+            mdnp.dealId,
+            uint256(Status.DealPublished)
+        );
         bytes memory payload = abi.encode(attest);
         if (chainId == block.chainid) {
-            IBridgeContract(chainIdToDestinationChain[chainId].destinationAddress)._execute(chainIdToDestinationChain[chainId].chainName, addressToHexString(address(this)), payload);
+            IBridgeContract(
+                chainIdToDestinationChain[chainId].destinationAddress
+            )._execute(
+                    chainIdToDestinationChain[chainId].chainName,
+                    addressToHexString(address(this)),
+                    payload
+                );
         } else {
             // If the chainId is not the current chain, we need to call the gateway
             // to forward the message to the correct chain
-            call_axelar(payload, proposal.provider.data, AXELAR_GAS_FEE, chainId);
+            call_axelar(
+                payload,
+                proposal.provider.data,
+                AXELAR_GAS_FEE,
+                chainId
+            );
         }
     }
 
-    function call_axelar(bytes memory payload, bytes memory providerAddrData, uint256 gasTarget, uint256 chainId) internal {
+    function call_axelar(
+        bytes memory payload,
+        bytes memory providerAddrData,
+        uint256 gasTarget,
+        uint256 chainId
+    ) internal {
         uint256 gasFunds = gasTarget;
         if (providerGasFunds[providerAddrData] >= gasTarget) {
             providerGasFunds[providerAddrData] -= gasTarget;
@@ -114,8 +150,11 @@ contract DealClient is AxelarExecutable {
             gasFunds = providerGasFunds[providerAddrData];
             providerGasFunds[providerAddrData] = 0;
         }
-        string memory destinationChain = chainIdToDestinationChain[chainId].chainName;
-        string memory destinationAddress = addressToHexString(chainIdToDestinationChain[chainId].destinationAddress);
+        string memory destinationChain = chainIdToDestinationChain[chainId]
+            .chainName;
+        string memory destinationAddress = addressToHexString(
+            chainIdToDestinationChain[chainId].destinationAddress
+        );
         gasService.payNativeGasForContractCall{value: gasFunds}(
             address(this),
             destinationChain,
@@ -126,23 +165,43 @@ contract DealClient is AxelarExecutable {
         gateway.callContract(destinationChain, destinationAddress, payload);
     }
 
-    function debug_call(bytes calldata commp, bytes calldata providerAddrData, uint256 gasFunds, uint256 chainId) public {
-        DataAttestation memory attest = DataAttestation(commp, 0, 42, uint256(Status.DealPublished));
+    function debug_call(
+        bytes calldata commp,
+        bytes calldata providerAddrData,
+        uint256 gasFunds,
+        uint256 chainId
+    ) public {
+        DataAttestation memory attest = DataAttestation(
+            commp,
+            0,
+            42,
+            uint256(Status.DealPublished)
+        );
         bytes memory payload = abi.encode(attest);
         if (chainId == block.chainid) {
-            IBridgeContract(chainIdToDestinationChain[chainId].destinationAddress)._execute(chainIdToDestinationChain[chainId].chainName, addressToHexString(address(this)), payload);
+            IBridgeContract(
+                chainIdToDestinationChain[chainId].destinationAddress
+            )._execute(
+                    chainIdToDestinationChain[chainId].chainName,
+                    addressToHexString(address(this)),
+                    payload
+                );
         } else {
             // If the chainId is not the current chain, we need to call the gateway
             // to forward the message to the correct chain
             call_axelar(payload, providerAddrData, gasFunds, chainId);
-        }    
+        }
     }
 
     // handle_filecoin_method is the universal entry point for any evm based
     // actor for a call coming from a builtin filecoin actor
     // @method - FRC42 method number for the specific method hook
     // @params - CBOR encoded byte array params
-    function handle_filecoin_method(uint64 method, uint64, bytes memory params) public returns (uint32, uint64, bytes memory) {
+    function handle_filecoin_method(
+        uint64 method,
+        uint64,
+        bytes memory params
+    ) public returns (uint32, uint64, bytes memory) {
         bytes memory ret;
         uint64 codec;
         // dispatch methods
@@ -156,12 +215,14 @@ contract DealClient is AxelarExecutable {
         } else if (method == MARKET_NOTIFY_DEAL_METHOD_NUM) {
             dealNotify(params);
         } else {
-            revert('the filecoin method that was called is not handled');
+            revert("the filecoin method that was called is not handled");
         }
         return (0, codec, ret);
     }
-    function addressToHexString(address _addr) internal pure returns (string memory) {
+
+    function addressToHexString(
+        address _addr
+    ) internal pure returns (string memory) {
         return Strings.toHexString(uint256(uint160(_addr)), 20);
     }
 }
-

--- a/src/Prover-Axelar.sol
+++ b/src/Prover-Axelar.sol
@@ -15,14 +15,13 @@ import { Misc } from "lib/filecoin-solidity/contracts/v0.8/utils/Misc.sol";
 import { FilAddresses } from "lib/filecoin-solidity/contracts/v0.8/utils/FilAddresses.sol";
 import { DataAttestation, IBridgeContract, StringsEqual } from "./Oracles.sol";
 import {Strings} from "lib/openzeppelin-contracts/contracts/utils/Strings.sol";
-import {Ownable} from "lib/openzeppelin-contracts/contracts/access/Ownable.sol";
 import {AxelarExecutable} from "lib/axelar-gmp-sdk-solidity/contracts/executable/AxelarExecutable.sol";
 import { IAxelarGateway } from 'lib/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGateway.sol';
 import { IAxelarGasService } from 'lib/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGasService.sol';
 
 using CBOR for CBOR.CBORBuffer;
 
-contract DealClient is AxelarExecutable, Ownable {
+contract DealClient is AxelarExecutable {
     using AccountCBOR for *;
     using MarketCBOR for *;
 
@@ -52,11 +51,12 @@ contract DealClient is AxelarExecutable, Ownable {
     mapping(bytes => uint256) public providerGasFunds; // Funds set aside for calling oracle by provider
     mapping(uint256 => DestinationChain) public chainIdToDestinationChain;
 
-    constructor(address _gateway, address _gasReceiver) AxelarExecutable(_gateway) Ownable(msg.sender) {
+    constructor(address _gateway, address _gasReceiver) AxelarExecutable(_gateway) {
         gasService = IAxelarGasService(_gasReceiver);
     }
 
-    function setDestinationChain(uint chainId, string memory destinationChain, address destinationAddress) public onlyOwner {
+    function setDestinationChain(uint chainId, string calldata destinationChain, address destinationAddress) external {
+        require(chainIdToDestinationChain[chainId].destinationAddress == address(0), "Destination chains already configured for the chainId");
         chainIdToDestinationChain[chainId] = DestinationChain(destinationChain, destinationAddress);
     }
 

--- a/src/Prover-Axelar.sol
+++ b/src/Prover-Axelar.sol
@@ -31,7 +31,7 @@ contract DealClient is AxelarExecutable {
     uint64 public constant MARKET_NOTIFY_DEAL_METHOD_NUM = 4186741094;
     address public constant MARKET_ACTOR_ETH_ADDRESS = address(0xff00000000000000000000000000000000000005);
     address public constant DATACAP_ACTOR_ETH_ADDRESS = address(0xfF00000000000000000000000000000000000007);
-    uint256 public constant AXELAR_GAS_FEE = 100000000000000000; // Start with 1 FIL 
+    uint256 public constant AXELAR_GAS_FEE = 100000000000000000; // Start with 0.1 FIL 
 
 
     struct DestinationChain {
@@ -55,9 +55,23 @@ contract DealClient is AxelarExecutable {
         gasService = IAxelarGasService(_gasReceiver);
     }
 
-    function setDestinationChain(uint chainId, string calldata destinationChain, address destinationAddress) external {
-        require(chainIdToDestinationChain[chainId].destinationAddress == address(0), "Destination chains already configured for the chainId");
-        chainIdToDestinationChain[chainId] = DestinationChain(destinationChain, destinationAddress);
+    function setDestinationChains(
+        uint[] calldata chainIds,
+        string[] calldata destinationChains,
+        address[] calldata destinationAddresses
+    ) external {
+        require(
+            chainIds.length == destinationChains.length && destinationChains.length == destinationAddresses.length,
+            "Input arrays must have the same length"
+        );
+    
+        for (uint i = 0; i < chainIds.length; i++) {
+            require(
+                chainIdToDestinationChain[chainIds[i]].destinationAddress == address(0),
+                "Destination chains already configured for the chainId"
+            );
+            chainIdToDestinationChain[chainIds[i]] = DestinationChain(destinationChains[i], destinationAddresses[i]);
+        }
     }
 
     function addGasFunds(bytes calldata providerAddrData) external payable {

--- a/src/Prover.sol
+++ b/src/Prover.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { MarketAPI } from "lib/filecoin-solidity/contracts/v0.8/MarketAPI.sol";
-import { CommonTypes } from "lib/filecoin-solidity/contracts/v0.8/types/CommonTypes.sol";
-import { MarketTypes } from "lib/filecoin-solidity/contracts/v0.8/types/MarketTypes.sol";
-import { AccountTypes } from "lib/filecoin-solidity/contracts/v0.8/types/AccountTypes.sol";
-import { CommonTypes } from "lib/filecoin-solidity/contracts/v0.8/types/CommonTypes.sol";
-import { AccountCBOR } from "lib/filecoin-solidity/contracts/v0.8/cbor/AccountCbor.sol";
-import { MarketCBOR } from "lib/filecoin-solidity/contracts/v0.8/cbor/MarketCbor.sol";
-import { BytesCBOR } from "lib/filecoin-solidity/contracts/v0.8/cbor/BytesCbor.sol";
-import { BigInts } from "lib/filecoin-solidity/contracts/v0.8/utils/BigInts.sol";
-import { CBOR } from "solidity-cborutils/contracts/CBOR.sol";
-import { Misc } from "lib/filecoin-solidity/contracts/v0.8/utils/Misc.sol";
-import { FilAddresses } from "lib/filecoin-solidity/contracts/v0.8/utils/FilAddresses.sol";
-import { DataAttestation, IBridgeContract } from "./Oracles.sol";
+import {MarketAPI} from "lib/filecoin-solidity/contracts/v0.8/MarketAPI.sol";
+import {CommonTypes} from "lib/filecoin-solidity/contracts/v0.8/types/CommonTypes.sol";
+import {MarketTypes} from "lib/filecoin-solidity/contracts/v0.8/types/MarketTypes.sol";
+import {AccountTypes} from "lib/filecoin-solidity/contracts/v0.8/types/AccountTypes.sol";
+import {CommonTypes} from "lib/filecoin-solidity/contracts/v0.8/types/CommonTypes.sol";
+import {AccountCBOR} from "lib/filecoin-solidity/contracts/v0.8/cbor/AccountCbor.sol";
+import {MarketCBOR} from "lib/filecoin-solidity/contracts/v0.8/cbor/MarketCbor.sol";
+import {BytesCBOR} from "lib/filecoin-solidity/contracts/v0.8/cbor/BytesCbor.sol";
+import {BigInts} from "lib/filecoin-solidity/contracts/v0.8/utils/BigInts.sol";
+import {CBOR} from "solidity-cborutils/contracts/CBOR.sol";
+import {Misc} from "lib/filecoin-solidity/contracts/v0.8/utils/Misc.sol";
+import {FilAddresses} from "lib/filecoin-solidity/contracts/v0.8/utils/FilAddresses.sol";
+import {DataAttestation, IBridgeContract} from "./Oracles.sol";
 import {Strings} from "lib/openzeppelin-contracts/contracts/utils/Strings.sol";
 
 using CBOR for CBOR.CBORBuffer;
@@ -25,8 +25,10 @@ contract DealClient {
     uint64 public constant AUTHENTICATE_MESSAGE_METHOD_NUM = 2643134072;
     uint64 public constant DATACAP_RECEIVER_HOOK_METHOD_NUM = 3726118371;
     uint64 public constant MARKET_NOTIFY_DEAL_METHOD_NUM = 4186741094;
-    address public constant MARKET_ACTOR_ETH_ADDRESS = address(0xff00000000000000000000000000000000000005);
-    address public constant DATACAP_ACTOR_ETH_ADDRESS = address(0xfF00000000000000000000000000000000000007);
+    address public constant MARKET_ACTOR_ETH_ADDRESS =
+        address(0xff00000000000000000000000000000000000005);
+    address public constant DATACAP_ACTOR_ETH_ADDRESS =
+        address(0xfF00000000000000000000000000000000000007);
 
     enum Status {
         None,
@@ -54,24 +56,43 @@ contract DealClient {
     // and the completion of this call marks the success of PublishStorageDeals
     // @params - cbor byte array of MarketDealNotifyParams
     function dealNotify(bytes memory params) internal {
-        require(msg.sender == MARKET_ACTOR_ETH_ADDRESS, "msg.sender needs to be market actor f05");
+        require(
+            msg.sender == MARKET_ACTOR_ETH_ADDRESS,
+            "msg.sender needs to be market actor f05"
+        );
 
-        MarketTypes.MarketDealNotifyParams memory mdnp = MarketCBOR.deserializeMarketDealNotifyParams(params);
-        MarketTypes.DealProposal memory proposal = MarketCBOR.deserializeDealProposal(mdnp.dealProposal);
+        MarketTypes.MarketDealNotifyParams memory mdnp = MarketCBOR
+            .deserializeMarketDealNotifyParams(params);
+        MarketTypes.DealProposal memory proposal = MarketCBOR
+            .deserializeDealProposal(mdnp.dealProposal);
 
         pieceDeals[proposal.piece_cid.data] = mdnp.dealId;
         pieceStatus[proposal.piece_cid.data] = Status.DealPublished;
 
-        int64 duration = CommonTypes.ChainEpoch.unwrap(proposal.end_epoch) - CommonTypes.ChainEpoch.unwrap(proposal.start_epoch);
-        DataAttestation memory attest = DataAttestation(proposal.piece_cid.data, duration, mdnp.dealId, uint256(Status.DealPublished));
-        bridgeContract._execute('FIL', addressToHexString(address(this)), abi.encode(attest));
+        int64 duration = CommonTypes.ChainEpoch.unwrap(proposal.end_epoch) -
+            CommonTypes.ChainEpoch.unwrap(proposal.start_epoch);
+        DataAttestation memory attest = DataAttestation(
+            proposal.piece_cid.data,
+            duration,
+            mdnp.dealId,
+            uint256(Status.DealPublished)
+        );
+        bridgeContract._execute(
+            "FIL",
+            addressToHexString(address(this)),
+            abi.encode(attest)
+        );
     }
 
     // handle_filecoin_method is the universal entry point for any evm based
     // actor for a call coming from a builtin filecoin actor
     // @method - FRC42 method number for the specific method hook
     // @params - CBOR encoded byte array params
-    function handle_filecoin_method(uint64 method, uint64, bytes memory params) public returns (uint32, uint64, bytes memory) {
+    function handle_filecoin_method(
+        uint64 method,
+        uint64,
+        bytes memory params
+    ) public returns (uint32, uint64, bytes memory) {
         bytes memory ret;
         uint64 codec;
         // dispatch methods
@@ -85,12 +106,14 @@ contract DealClient {
         } else if (method == MARKET_NOTIFY_DEAL_METHOD_NUM) {
             dealNotify(params);
         } else {
-            revert('the filecoin method that was called is not handled');
+            revert("the filecoin method that was called is not handled");
         }
         return (0, codec, ret);
     }
-    function addressToHexString(address _addr) internal pure returns (string memory) {
+
+    function addressToHexString(
+        address _addr
+    ) internal pure returns (string memory) {
         return Strings.toHexString(uint256(uint160(_addr)), 20);
     }
 }
-

--- a/src/Token.sol
+++ b/src/Token.sol
@@ -1,28 +1,40 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract Nickle is ERC20 {
     constructor() ERC20("Nickle", "NICKLE") {
-        _mint(msg.sender, 10000000000000000000000000000000000000000000000000000000000000000);
+        _mint(
+            msg.sender,
+            10000000000000000000000000000000000000000000000000000000000000000
+        );
     }
 }
 
 contract BronzeCowry is ERC20 {
     constructor() ERC20("Bronze Cowry", "SHELL") {
-        _mint(msg.sender, 10000000000000000000000000000000000000000000000000000000000000000);
+        _mint(
+            msg.sender,
+            10000000000000000000000000000000000000000000000000000000000000000
+        );
     }
 }
 
 contract AthenianDrachma is ERC20 {
     constructor() ERC20("Athenian Drachma", "ATH") {
-        _mint(msg.sender, 10000000000000000000000000000000000000000000000000000000000000000);
+        _mint(
+            msg.sender,
+            10000000000000000000000000000000000000000000000000000000000000000
+        );
     }
 }
 
-
 contract DebasedTowerPoundSterling is ERC20 {
     constructor() ERC20("DebasedTowerPoundSterling", "NEWTON") {
-        _mint(msg.sender, 10000000000000000000000000000000000000000000000000000000000000000);
+        _mint(
+            msg.sender,
+            10000000000000000000000000000000000000000000000000000000000000000
+        );
     }
 }


### PR DESCRIPTION
- Configures smart contract flow to handle deals from various chains
- Expects `chainId` to be sent as `bytes` through `proposal.label`
- configures only owner function to populate chain name and address in struct mapped with chainId to make cross chain axelar calls
- In case of native filecoin call it calls mock bridge through `IBridgeContract` on same chain
- Configures xchain to send `chainId` in deal label.
- Implements test to check abi encoding and decoding properly for xchain